### PR TITLE
jquery via cdn

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -57,6 +57,16 @@
       href="img/favicon/safari-pinned-tab.svg"
       color="#5bbad5"
     />
+    <script
+      src="https://code.jquery.com/jquery-3.5.1.min.js"
+      integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"
+      integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU="
+      crossorigin="anonymous"
+    ></script>
   </head>
 
   <body>

--- a/src/js/App.ts
+++ b/src/js/App.ts
@@ -1,11 +1,9 @@
 // ASCII text: http://patorjk.com/software/taag/#p=display&h=2&f=Doh&t=TOOLS
 
 /*
-
   To switch to photoshop style layers:
   - load "List_layerstyle.js" instead of "List.js" in index.html
   - comment & uncomment 2 lines of code in update_ui in this file
-
 */
 
 import $ from "jquery";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,13 +5,16 @@ const webpack = require("webpack"); //to access built-in plugins
 var path = require("path");
 
 const config = {
-  entry: ["webpack-jquery-ui", "./src/js/App.ts"],
+  entry: ["./src/js/App.ts"],
   output: {
     filename: "bundle.js",
     path: path.resolve(__dirname, "dist"),
   },
   resolve: {
     extensions: [".ts", ".js"],
+  },
+  externals: {
+    jquery: "jQuery",
   },
   module: {
     rules: [


### PR DESCRIPTION
jquery is still in the dependencies, but not bundled anymore. 
Instead, the index references the cdn minified versions.
greatly speeds up bundling (10secs down to 4 secs) and bundle size (584kb down to 294kb)
