### PR TITLE
"embedded deployment" (relative base path, instead of absolute)

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -15,5 +15,5 @@ export default defineConfig({
     outDir: 'dist',
     assetsDir: 'assets', // Default asset directory, you can change if needed
   },
-  base: '/', // Make sure this is correct for production
+  base: './', // Make sure this is correct for production
 });


### PR DESCRIPTION
Hey there,

I just found out that Spritemate received a few cool updates over the last few months! Yay! :-D

So I happily tried to update my "Electron wrapper app" ([spritemate4electron](https://github.com/4ch1m/spritemate4electron)) as well.

However, I found out that the latest version of Spritemate is referring to the main js-file with an absolute path.

```
...
    <!-- Main application script -->
    <script type="module" crossorigin src="/assets/index-Clp4cfLG.js"></script>
  </head>
...
```

Unfortunately, this breaks the Electron app, which contains the original Spritemate code/distribution in a subfolder and expects all further resources to be reachable via a relative url.

So... I was wondering if you could change the base path of the Vite config accordingly; so that we'll end up with an "embedded deployment"?

(see also: https://vite.dev/config/shared-options.html#base)

Thanks for reading... and thanks for Spritemate! :bow:
